### PR TITLE
change the fn.func_code to fn.__code__ for fit with python3x

### DIFF
--- a/augment.py
+++ b/augment.py
@@ -34,7 +34,7 @@ def _get_args_and_name(fn):
     allargs, fn_name = getattr(fn, '__allargs__', None), \
             getattr(fn, '__fnname__', None)
     if not allargs:
-        code = fn.func_code
+        code = fn.__code__
         allargs = code.co_varnames[:code.co_argcount]
         fn_name = fn.__name__
     return allargs, fn_name


### PR DESCRIPTION
Hello author, 

I am using the augment library on some old repo, and when try to import TrivialAugmentWide inside the code I saw the problem 

`AttributeError: 'function' object has no attribute 'func_code'`

So this pull request is for fixing the import error above